### PR TITLE
New features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,10 +27,12 @@ serde_zod = { git = "https://github.com/shakyShane/serde-zod.git#main" }
   - [x] fall back to `z.union` if fields are mixed
 - [x] array subtype via `Vec<T>`
 - [x] optional types `Option<T>`
-- [ ] HashMap/BTreeMap
+- [x] HashMap/BTreeMap
 - [ ] Set/BTreeSet
 - [ ] serde rename_all
 - [ ] serde rename_field
+  - [x] basic functionality
+  - [ ] independent names for serialization / deserialization
 - [ ] document all available output types
 
 | rust                                   | zod                              |
@@ -39,7 +41,8 @@ serde_zod = { git = "https://github.com/shakyShane/serde-zod.git#main" }
 | enum with "tagged" variants            | z.discriminatedUnion("tag", ...) |
 | enum with mixed variants               | z.union([...])                   |
 | String                                 | z.string()                       |
-| usize\|u8\|u16\|f32\|f64 etc (numbers) | z.number()                    |
+| usize\|u8\|u16\|f32\|f64 etc (numbers) | z.number()                       |
+| bool                                   | z.boolean()                      |
 | Option<String>                         | z.string().optional()            |
 | Struct/Enum fields                     | z.object({ ... })                |
 

--- a/serde-zod/src/get_serde_rename.rs
+++ b/serde-zod/src/get_serde_rename.rs
@@ -1,0 +1,33 @@
+use quote::ToTokens;
+use syn::Attribute;
+
+pub fn get_serde_rename(attrs: &Vec<Attribute>) -> Option<String> {
+    for attr in attrs {
+        if (attr.path.segments.len() != 1) || (attr.path.segments.first().unwrap().ident != "serde")
+        {
+            continue;
+        }
+        let Ok(input) = syn::parse2::<proc_macro2::Group>(attr.tokens.clone()) else {
+            continue;
+        };
+        let mut stream = input.stream().into_iter();
+        let Some(indent) = stream.next() else { continue };
+        let Ok(indent) = syn::parse2::<proc_macro2::Ident>(indent.into_token_stream()) else { continue };
+        if &indent.to_string() != "rename" {
+            continue;
+        }
+        let Some(punct) = stream.next() else { continue };
+        let Ok(punct) = syn::parse2::<proc_macro2::Punct>(punct.into_token_stream()) else { continue };
+        if &punct.to_string() != "=" {
+            continue;
+        }
+        let Some(literal) = stream.next() else { continue };
+        let Ok(literal) = syn::parse2::<proc_macro2::Literal>(literal.into_token_stream()) else { continue };
+
+        let new_name = literal.to_string();
+        let Some(new_name) = new_name.strip_suffix('"') else { continue };
+        let Some(new_name) = new_name.strip_prefix('"') else { continue };
+        return Some(new_name.to_string());
+    }
+    None
+}

--- a/serde-zod/src/types/ty.rs
+++ b/serde-zod/src/types/ty.rs
@@ -7,10 +7,13 @@ use std::fmt::Write;
 pub enum Ty {
     ZodNumber,
     ZodString,
+    ZodBoolean,
     InlineObject(InlineObject),
     Reference(String),
     Seq(Box<Ty>),
     Optional(Box<Ty>),
+    Record(Box<Ty>, Box<Ty>),
+    Tuple(Vec<Ty>),
 }
 
 impl Ty {
@@ -19,6 +22,9 @@ impl Ty {
     }
     pub fn optional(ty: Ty) -> Self {
         Self::Optional(Box::new(ty))
+    }
+    pub fn record(key: Ty, value: Ty) -> Self {
+        Self::Record(Box::new(key), Box::new(value))
     }
 }
 
@@ -29,6 +35,7 @@ impl std::fmt::Display for Ty {
         let named: String = match self {
             Ty::ZodNumber => "Ty::ZodNumber".to_string(),
             Ty::ZodString => "Ty::ZodString".to_string(),
+            Ty::ZodBoolean => "Ty::ZodBoolean".to_string(),
             Ty::Reference(_) => "Ty::Reference".to_string(),
             Ty::Seq(inner) => {
                 format!("Ty::Seq({})", inner)
@@ -37,6 +44,10 @@ impl std::fmt::Display for Ty {
                 format!("Ty::Optional({})", inner)
             }
             Ty::InlineObject(_) => "Ty::InlineObject(..)".to_string(),
+            Ty::Record(key, value) => {
+                format!("Ty::Record({key}, {value})")
+            }
+            Ty::Tuple(i) => format!("Ty::InlineObject([_; {}])", i.len()),
         };
         writeln!(f, "{}", named)?;
         writeln!(f, "\t{}", as_zod)
@@ -48,6 +59,7 @@ impl Print for Ty {
         let res = match self {
             Ty::ZodNumber => "z.number()".to_string(),
             Ty::ZodString => "z.string()".to_string(),
+            Ty::ZodBoolean => "z.boolean()".to_string(),
             Ty::Reference(raw_ref) => raw_ref.to_string(),
             Ty::Seq(inner) => format!("z.array({})", inner.as_string().expect("local type")),
             Ty::Optional(inner) => format!(
@@ -55,6 +67,20 @@ impl Print for Ty {
                 inner.as_string().expect("local inner optional type")
             ),
             Ty::InlineObject(fields) => fields.as_string()?,
+            Ty::Record(key, value) => {
+                format!(
+                    "z.record({}, {})",
+                    key.as_string().expect("local type"),
+                    value.as_string().expect("local type")
+                )
+            }
+            Ty::Tuple(inner) => {
+                let mut collect = Vec::with_capacity(inner.len());
+                for i in inner.iter() {
+                    collect.push(i.as_string().expect("local type"));
+                }
+                format!("z.tuple([{}])", collect.join(", "))
+            }
         };
         write!(x, "{}", res)
     }


### PR DESCRIPTION
- basic functionality for rename field attribute
- BTreeMap & HashMap using `z.record()`
- u16 / i16 / bool work now
- tuples work now
